### PR TITLE
Fix panic when using ed25519 with a key that is not 64 bytes long

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -190,6 +190,9 @@ func (s Signer) sign(buff []byte) ([]byte, error) {
 		return ecdsaSignRaw(rand.Reader, &key, hashed[:])
 	case "ed25519":
 		key := s.key.(ed25519.PrivateKey)
+		if len(key) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("key must be %d bytes long", ed25519.PrivateKeySize)
+		}
 		return ed25519.Sign(key, buff), nil
 	default:
 		return nil, fmt.Errorf("sign: unknown algorithm \"%s\"", s.alg)

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -1,6 +1,7 @@
 package httpsign
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -93,6 +94,18 @@ func TestSigner_sign(t *testing.T) {
 			fields: fields{
 				key: []byte(strings.Repeat("a", 64)),
 				alg: "hmac-sha999",
+			},
+			args: args{
+				buff: []byte("abc"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "ed25519 key not 64 bytes",
+			fields: fields{
+				key: ed25519.PrivateKey(strings.Repeat("a", 63)),
+				alg: "ed25519",
 			},
 			args: args{
 				buff: []byte("abc"),


### PR DESCRIPTION
Hi @yaronf,

This PR avoids a panic caused by an incorrectly sized ed25519 key. 

Hope it helps, and thanks for building this awesome library!